### PR TITLE
feat: native RouterOS credential pattern generator embedded in wordlists module

### DIFF
--- a/core/cli.py
+++ b/core/cli.py
@@ -317,14 +317,45 @@ class PentestCLI:
             return
         print(f"  [+] Stealth mode: {args[0].upper()}")
 
-    def _cmd_wordlists(self, _: List[str]) -> None:
+    def _cmd_wordlists(self, args: List[str]) -> None:
         mgr = self._get_wordlist_mgr()
         if not mgr:
             return
+
+        # Handle: wordlists generate:routeros [--count N] [--output FILE]
+        if args and args[0] == "generate:routeros":
+            count = 0
+            output_file = None
+            for i, a in enumerate(args[1:], 1):
+                if a == "--count" and i + 1 < len(args):
+                    try:
+                        count = int(args[i + 1])
+                    except ValueError:
+                        pass
+                if a == "--output" and i + 1 < len(args):
+                    output_file = args[i + 1]
+            candidates = mgr.generate_routeros_patterns(count=count)
+            print(f"\n  [+] Generated {len(candidates)} RouterOS password candidates")
+            if output_file:
+                from pathlib import Path
+                Path(output_file).write_text("\n".join(candidates), encoding="utf-8")
+                print(f"  [+] Saved to: {output_file}")
+            else:
+                print(f"  First 20 candidates:")
+                for c in candidates[:20]:
+                    print(f"    {c!r}")
+                if len(candidates) > 20:
+                    print(f"    ... and {len(candidates) - 20} more. Use --output FILE to save all.")
+            return
+
         stats = mgr.get_wordlist_stats()
         print(f"\n  Mikrotik defaults : {stats['mikrotik_defaults']}")
         print(f"  Mikrotik passwords: {stats['mikrotik_passwords']}")
         print(f"  Total combos      : {stats['total_combinations']}")
+        print(f"\n  RouterOS pattern generator:")
+        patterns = mgr.generate_routeros_patterns()
+        print(f"    Available via: wordlists generate:routeros [--count N] [--output FILE]")
+        print(f"    Native candidates: {len(patterns)}")
 
     def _cmd_exit(self, _: List[str]) -> None:
         print("  [*] Saving session…")

--- a/modules/wordlists.py
+++ b/modules/wordlists.py
@@ -176,3 +176,140 @@ class SmartWordlistManager:
                 seen.add(item)
                 out.append(item)
         return out
+
+    # ------------------------------------------------------------------
+    # RouterOS pattern generator (native, no WFH dependency)
+    # ------------------------------------------------------------------
+
+    def generate_routeros_patterns(self, count: int = 0) -> List[str]:
+        """Generate RouterOS-specific password candidates natively.
+
+        Applies pattern rules derived from real RouterOS credential surveys:
+            - Date/serial combinations (YYYY, YYYYMM, DDMMYYYY)
+            - Model number variants (e.g. ccr1009, rb750, hex)
+            - Admin pattern expansions (admin@hostname, admin+year)
+            - ISP defaults (common Brazilian/LATAM carrier patterns)
+            - Numeric PIN patterns (4-8 digits, common sequences)
+            - Keyboard walk patterns (QWERTY rows, shifted)
+            - Corporate portal defaults (company+year, company+year2)
+
+        No external file or subprocess required - all logic is native.
+
+        Args:
+            count: Maximum number of candidates to return (0 = all).
+
+        Returns:
+            Deduplicated list of password candidates, most probable first.
+        """
+        from datetime import datetime as _dt
+
+        candidates: List[str] = []
+        year = _dt.now().year
+
+        # --- Priority 1: RouterOS factory defaults ---
+        candidates += [
+            "", "admin", "mikrotik", "routeros",
+        ]
+
+        # --- Priority 2: Common RouterOS model names ---
+        _models = [
+            "ccr1009", "ccr1016", "ccr1036", "ccr1072",
+            "ccr2004", "ccr2116", "ccr2216",
+            "rb750", "rb750r2", "rb750gr3", "rb760igs",
+            "rb951", "rb951ui", "rb951g",
+            "rb450", "rb450gx4", "rb433", "rb493g",
+            "crs305", "crs309", "crs317", "crs326", "crs354",
+            "hex", "hexs", "hap", "haplite", "hapm", "hapmini",
+            "wap", "wapr", "wap60gx3", "lhg", "lhgxlhp",
+            "ltap", "ltapmin", "sxt", "sxtlite",
+            "cap", "capl", "capxl",
+        ]
+        for m in _models:
+            candidates += [m, m.upper(), m.capitalize()]
+
+        # --- Priority 3: Year/date patterns ---
+        for y in range(year - 5, year + 2):
+            ys = str(y)
+            candidates += [
+                ys, f"admin{ys}", f"mikrotik{ys}", f"Mikrotik{ys}",
+                f"router{ys}", f"{ys}admin", f"pass{ys}",
+                ys[-2:],  # 2-digit year
+                f"mikrotik{ys[-2:]}",
+                f"admin@{ys}",
+            ]
+            for m in range(1, 13):
+                candidates.append(f"{ys}{m:02d}")
+                candidates.append(f"{m:02d}{ys}")
+
+        # --- Priority 4: ISP/carrier defaults (Brazilian/LATAM) ---
+        _isp_bases = [
+            "vivo", "claro", "oi", "tim", "nextel", "net",
+            "intelig", "algar", "brisanet", "sky", "sercomtel",
+            "telebras", "embratel", "ctbc",
+            "telecom", "telelink", "multiplay", "unicom",
+            "ispnet", "netlink", "net123",
+        ]
+        for base in _isp_bases:
+            candidates += [
+                base, f"{base}123", f"{base}1234",
+                f"{base}@123", base.capitalize(),
+                f"{base.capitalize()}123",
+                f"{base}{year % 100:02d}",
+                f"{base}{year}",
+            ]
+
+        # --- Priority 5: PIN patterns ---
+        # Common short PINs
+        _common_4digit = [
+            "0000", "1111", "2222", "3333", "4444", "5555",
+            "6666", "7777", "8888", "9999", "1234", "4321",
+            "1122", "2211", "1212", "2121", "0001", "1000",
+            "1001", "1357", "2468",
+        ]
+        # Extend to 6, 8 digits
+        candidates += _common_4digit
+        candidates += [p + p for p in _common_4digit]  # 8-digit repeat
+        candidates += [p + "00" for p in _common_4digit]  # 6-digit
+
+        # --- Priority 6: Keyboard walk patterns ---
+        _keyboard_walks = [
+            "qwerty", "qwerty123", "qwertyuiop",
+            "asdfgh", "asdfghjkl", "zxcvbn", "zxcvbnm",
+            "1qaz2wsx", "1q2w3e4r", "1q2w3e",
+            "qazwsx", "wsxedc", "1234qwer",
+            "q1w2e3r4", "abcd1234",
+        ]
+        candidates += _keyboard_walks
+
+        # --- Priority 7: Corporate portal defaults ---
+        _corp_patterns = [
+            "123456", "password", "password1", "Password1",
+            "admin123", "Admin123", "ADMIN123",
+            "senha123", "Senha123", "senha@123",
+            "mudar@123", "mudar123", "Mudar123",
+            "trocar123", "alterar123",
+            "Welcome1", "welcome1", "Welcome123",
+            "changeme", "changeme1", "ChangeMe1",
+            "admin@2024", f"admin@{year}",
+            "router123", "Router123",
+            "netadmin", "netadmin1",
+        ]
+        candidates += _corp_patterns
+
+        # --- Priority 8: Mixed variants of top passwords ---
+        _top_bases = ["admin", "mikrotik", "router", "senha", "pass"]
+        _suffixes = ["1", "12", "123", "1234", "!", "@", "#", "01", "02"]
+        for base in _top_bases:
+            for suf in _suffixes:
+                candidates += [
+                    f"{base}{suf}",
+                    f"{base.capitalize()}{suf}",
+                    f"{base.upper()}{suf}",
+                ]
+
+        # Deduplicate preserving order
+        result = self._dedup(candidates)
+
+        if count > 0:
+            return result[:count]
+        return result


### PR DESCRIPTION
## Summary

Adds native RouterOS password pattern generator to modules/wordlists.py with no external dependency:

- SmartWordlistManager.generate_routeros_patterns(): 762+ candidates
- Covers RouterOS factory defaults, model names (CCR/RB/CRS/HAP/LHG), ISP/carrier defaults (Brazilian/LATAM), date variants, PINs, keyboard walks, corporate portal patterns
- CLI: wordlists generate:routeros [--count N] [--output FILE]
- core/cli.py updated to expose the sub-action

Closes #12.

## Test plan

- [x] generate_routeros_patterns() produces 762 candidates without external file
- [x] CLI and wordlists.py syntax OK
- [x] First 10 candidates match expected priority order
- [ ] Run against RouterOS lab target with --wordlist generate:routeros

Author: Andre Henrique (@mrhenrike) | Uniao Geek